### PR TITLE
Remove unnecessary double hrefs

### DIFF
--- a/src/app/amopis/layout.tsx
+++ b/src/app/amopis/layout.tsx
@@ -25,16 +25,16 @@ function Amopis({ children }: { children: React.ReactNode }) {
               <Grid.Cell span="all">
                 <PageMenu>
                   <Link legacyBehavior href="/amopis" passHref>
-                    <PageMenu.Link href="/amopis">Kerngegevens</PageMenu.Link>
+                    <PageMenu.Link>Kerngegevens</PageMenu.Link>
                   </Link>
                   <Link legacyBehavior href="/amopis/ramingen" passHref>
-                    <PageMenu.Link href="/amopis/ramingen">Ramingen</PageMenu.Link>
+                    <PageMenu.Link>Ramingen</PageMenu.Link>
                   </Link>
                   <PageMenu.Link href="#">E-mail je vraag of feedback</PageMenu.Link>
                   <PageMenu.Link href="#">Bekijk veelgestelde vragen</PageMenu.Link>
                   <PageMenu.Link href="#">Bekijk releasebeschrijving</PageMenu.Link>
                   <Link legacyBehavior href="/" passHref>
-                    <PageMenu.Link href="/">Prototypes</PageMenu.Link>
+                    <PageMenu.Link>Prototypes</PageMenu.Link>
                   </Link>
                 </PageMenu>
               </Grid.Cell>

--- a/src/app/amsterdam/burgerzaken/page.tsx
+++ b/src/app/amsterdam/burgerzaken/page.tsx
@@ -87,7 +87,7 @@ function Burgerzaken() {
         <Grid.Cell span="all">
           <Breadcrumb>
             <NextLink legacyBehavior passHref href="/amsterdam">
-              <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+              <Breadcrumb.Link>Home</Breadcrumb.Link>
             </NextLink>
           </Breadcrumb>
         </Grid.Cell>

--- a/src/app/amsterdam/contact/bedankt/page.tsx
+++ b/src/app/amsterdam/contact/bedankt/page.tsx
@@ -9,7 +9,7 @@ function Bedankt() {
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Breadcrumb>
           <NextLink legacyBehavior passHref href="/amsterdam">
-            <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+            <Breadcrumb.Link>Home</Breadcrumb.Link>
           </NextLink>
         </Breadcrumb>
         <Column className="ams-mb--md" gap="small">
@@ -24,7 +24,7 @@ function Bedankt() {
             mogelijk op.
           </Paragraph>
           <NextLink legacyBehavior passHref href="/amsterdam">
-            <Link href="/amsterdam">Ga terug naar de homepage.</Link>
+            <Link>Ga terug naar de homepage.</Link>
           </NextLink>
         </Column>
       </Grid.Cell>

--- a/src/app/amsterdam/contact/gegevens/page.tsx
+++ b/src/app/amsterdam/contact/gegevens/page.tsx
@@ -33,7 +33,7 @@ function Question() {
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Breadcrumb>
           <NextLink legacyBehavior passHref href="/amsterdam">
-            <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+            <Breadcrumb.Link>Home</Breadcrumb.Link>
           </NextLink>
         </Breadcrumb>
         <form className="ams-gap--md" onSubmit={handleSubmit}>

--- a/src/app/amsterdam/contact/page.tsx
+++ b/src/app/amsterdam/contact/page.tsx
@@ -18,7 +18,7 @@ function Contact() {
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Breadcrumb>
           <NextLink legacyBehavior passHref href="/amsterdam">
-            <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+            <Breadcrumb.Link>Home</Breadcrumb.Link>
           </NextLink>
         </Breadcrumb>
         <form className="ams-gap--md" onSubmit={handleSubmit}>

--- a/src/app/amsterdam/contact/vraag/page.tsx
+++ b/src/app/amsterdam/contact/vraag/page.tsx
@@ -32,7 +32,7 @@ function Question() {
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Breadcrumb>
           <NextLink legacyBehavior passHref href="/amsterdam">
-            <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+            <Breadcrumb.Link>Home</Breadcrumb.Link>
           </NextLink>
         </Breadcrumb>
         <form className="ams-gap--md" onSubmit={handleSubmit}>

--- a/src/app/amsterdam/kunst-en-cultuur/page.tsx
+++ b/src/app/amsterdam/kunst-en-cultuur/page.tsx
@@ -23,7 +23,7 @@ function KunstEnCultuur() {
         <Grid.Cell span="all">
           <Breadcrumb>
             <NextLink legacyBehavior passHref href="/amsterdam">
-              <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+              <Breadcrumb.Link>Home</Breadcrumb.Link>
             </NextLink>
           </Breadcrumb>
         </Grid.Cell>

--- a/src/app/amsterdam/layout.tsx
+++ b/src/app/amsterdam/layout.tsx
@@ -211,7 +211,7 @@ function Amsterdam({ children }) {
             <PageMenu>
               {footerLinks.map(({ href, label }) => (
                 <NextLink legacyBehavior href={href} passHref key={label}>
-                  <PageMenu.Link href={href}>{label}</PageMenu.Link>
+                  <PageMenu.Link>{label}</PageMenu.Link>
                 </NextLink>
               ))}
             </PageMenu>

--- a/src/app/amsterdam/nieuws/page.tsx
+++ b/src/app/amsterdam/nieuws/page.tsx
@@ -12,7 +12,7 @@ function Nieuws() {
         <Grid.Cell span="all">
           <Breadcrumb>
             <NextLink legacyBehavior passHref href="/amsterdam">
-              <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+              <Breadcrumb.Link>Home</Breadcrumb.Link>
             </NextLink>
             <Breadcrumb.Link href="#">Nieuws</Breadcrumb.Link>
           </Breadcrumb>

--- a/src/app/amsterdam/projecten/page.tsx
+++ b/src/app/amsterdam/projecten/page.tsx
@@ -23,7 +23,7 @@ function Projecten() {
         <Grid.Cell span="all">
           <Breadcrumb>
             <NextLink legacyBehavior passHref href="/amsterdam">
-              <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+              <Breadcrumb.Link>Home</Breadcrumb.Link>
             </NextLink>
           </Breadcrumb>
         </Grid.Cell>
@@ -46,9 +46,7 @@ function Projecten() {
           <LinkList>
             {['Centrum', 'Nieuw-West', 'Noord', 'Oost', 'Weesp', 'West', 'Zuid', 'Zuidoost'].map((district) => (
               <NextLink legacyBehavior passHref href="/amsterdam/projecten/project">
-                <LinkList.Link href="/amsterdam/projecten/project" key={district}>
-                  {district}
-                </LinkList.Link>
+                <LinkList.Link key={district}>{district}</LinkList.Link>
               </NextLink>
             ))}
           </LinkList>

--- a/src/app/amsterdam/projecten/project/page.tsx
+++ b/src/app/amsterdam/projecten/project/page.tsx
@@ -23,10 +23,10 @@ function Project() {
         <Grid.Cell span="all">
           <Breadcrumb>
             <NextLink legacyBehavior passHref href="/amsterdam">
-              <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+              <Breadcrumb.Link>Home</Breadcrumb.Link>
             </NextLink>
             <NextLink legacyBehavior passHref href="/amsterdam/projecten">
-              <Breadcrumb.Link href="/amsterdam/projecten">Home</Breadcrumb.Link>
+              <Breadcrumb.Link>Home</Breadcrumb.Link>
             </NextLink>
           </Breadcrumb>
         </Grid.Cell>

--- a/src/app/amsterdam/zoeken/page.tsx
+++ b/src/app/amsterdam/zoeken/page.tsx
@@ -59,7 +59,7 @@ function Zoeken() {
       <Grid.Cell span={{ narrow: 4, medium: 5, wide: 8 }} start={{ narrow: 1, medium: 4, wide: 5 }}>
         <Breadcrumb>
           <NextLink legacyBehavior passHref href="/amsterdam">
-            <Breadcrumb.Link href="/amsterdam">Home</Breadcrumb.Link>
+            <Breadcrumb.Link>Home</Breadcrumb.Link>
           </NextLink>
           <Breadcrumb.Link href="#">Zoekresultaten</Breadcrumb.Link>
         </Breadcrumb>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,13 +14,13 @@ export default function Page() {
           </Heading>
           <LinkList>
             <Link legacyBehavior href="/amopis" passHref>
-              <LinkList.Link href="/amopis">Amopis</LinkList.Link>
+              <LinkList.Link>Amopis</LinkList.Link>
             </Link>
             <Link legacyBehavior href="/amsterdam" passHref>
-              <LinkList.Link href="/amsterdam">Amsterdam</LinkList.Link>
+              <LinkList.Link>Amsterdam</LinkList.Link>
             </Link>
             <Link legacyBehavior href="/signalen" passHref>
-              <LinkList.Link href="/signalen">Signalen</LinkList.Link>
+              <LinkList.Link>Signalen</LinkList.Link>
             </Link>
           </LinkList>
         </Grid.Cell>


### PR DESCRIPTION
I originally thought we required `href`s for all our link components, but that isn't the case. This PR removes the unnecessary `href`s.