### PR TITLE
fix: Wrap all functional navigation in Next Links

### DIFF
--- a/.plop/templates/SiteLayout.tsx.hbs
+++ b/.plop/templates/SiteLayout.tsx.hbs
@@ -59,7 +59,7 @@ export default function {{pascalCase name}}({ children }) {
           <Grid paddingVertical="small">
             <Grid.Cell span="all">
               <PageMenu>
-                <NextLink  href="/" legacyBehavior passHref>
+                <NextLink href="/" legacyBehavior passHref>
                   <Header.MenuLink>Prototypes</Header.MenuLink>
                 </NextLink>
                 <PageMenu.Link href="#">Over deze site</PageMenu.Link>

--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -24,9 +24,9 @@ export default function (plop) {
         type: 'append',
         path: 'src/app/page.tsx',
         pattern: '{/* Append route import here */}',
-        template: `            <Link legacyBehavior href="/{{kebabCase name}}" passHref>
+        template: `            <NextLink href="/{{kebabCase name}}" legacyBehavior passHref>
               <LinkList.Link>{{titleCase name}}</LinkList.Link>
-            </Link>`,
+            </NextLink>`,
       },
     ],
   })

--- a/src/app/amopis/layout.tsx
+++ b/src/app/amopis/layout.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode } from 'react'
 import { Avatar, Column, Grid, Header, PageMenu, Screen, SkipLink } from '@amsterdam/design-system-react'
-import Link from 'next/link'
+import NextLink from 'next/link'
 
 import { Sidebar } from './_components/SideBar/SideBar'
 
@@ -29,18 +29,18 @@ function Amopis({ children }: { children: ReactNode }) {
             <Grid paddingVertical="small">
               <Grid.Cell span="all">
                 <PageMenu>
-                  <Link href="/amopis" legacyBehavior passHref>
+                  <NextLink href="/amopis" legacyBehavior passHref>
                     <PageMenu.Link>Kerngegevens</PageMenu.Link>
-                  </Link>
-                  <Link href="/amopis/ramingen" legacyBehavior passHref>
+                  </NextLink>
+                  <NextLink href="/amopis/ramingen" legacyBehavior passHref>
                     <PageMenu.Link>Ramingen</PageMenu.Link>
-                  </Link>
+                  </NextLink>
                   <PageMenu.Link href="#">E-mail je vraag of feedback</PageMenu.Link>
                   <PageMenu.Link href="#">Bekijk veelgestelde vragen</PageMenu.Link>
                   <PageMenu.Link href="#">Bekijk releasebeschrijving</PageMenu.Link>
-                  <Link href="/" legacyBehavior passHref>
+                  <NextLink href="/" legacyBehavior passHref>
                     <PageMenu.Link>Prototypes</PageMenu.Link>
-                  </Link>
+                  </NextLink>
                 </PageMenu>
               </Grid.Cell>
             </Grid>

--- a/src/app/amsterdam/bestuur-en-organisatie/college-van-burgemeester-en-wethouders/page.tsx
+++ b/src/app/amsterdam/bestuur-en-organisatie/college-van-burgemeester-en-wethouders/page.tsx
@@ -115,7 +115,9 @@ export default function CollegeVanBurgemeesterEnWethouders() {
             <NextLink href="/amsterdam" legacyBehavior passHref>
               <Breadcrumb.Link>Home</Breadcrumb.Link>
             </NextLink>
-            <Breadcrumb.Link href="/amsterdam/bestuur-en-organisatie">Bestuur en Organisatie</Breadcrumb.Link>
+            <NextLink href="/amsterdam/bestuur-en-organisatie" legacyBehavior passHref>
+              <Breadcrumb.Link>Bestuur en Organisatie</Breadcrumb.Link>
+            </NextLink>
           </Breadcrumb>
           <PageHeading className="ams-mb--sm">College van burgemeester en wethouders</PageHeading>
           <Paragraph size="large">Het dagelijks bestuur van onze gemeente uitgebreid in beeld.</Paragraph>

--- a/src/app/amsterdam/bestuur-en-organisatie/gemeenteraad/page.tsx
+++ b/src/app/amsterdam/bestuur-en-organisatie/gemeenteraad/page.tsx
@@ -71,7 +71,9 @@ export default function Gemeenteraad() {
             <NextLink href="/amsterdam" legacyBehavior passHref>
               <Breadcrumb.Link>Home</Breadcrumb.Link>
             </NextLink>
-            <Breadcrumb.Link href="/amsterdam/bestuur-en-organisatie">Bestuur en Organisatie</Breadcrumb.Link>
+            <NextLink href="/amsterdam/bestuur-en-organisatie" legacyBehavior passHref>
+              <Breadcrumb.Link>Bestuur en Organisatie</Breadcrumb.Link>
+            </NextLink>
           </Breadcrumb>
           <PageHeading className="ams-mb--sm">Gemeenteraad</PageHeading>
           <Paragraph size="large">

--- a/src/app/amsterdam/bestuur-en-organisatie/page.tsx
+++ b/src/app/amsterdam/bestuur-en-organisatie/page.tsx
@@ -19,7 +19,9 @@ function Subsection({ isEven, title }: SubsectionProps) {
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={isEven ? { narrow: 1, medium: 1, wide: 2 } : undefined}>
       <Card>
         <Heading level={3} size="level-4">
-          <Card.Link href={linkUrls[title] ?? '#'}>{title}</Card.Link>
+          <NextLink href={linkUrls[title] ?? '#'} legacyBehavior passHref>
+            <Card.Link>{title}</Card.Link>
+          </NextLink>
         </Heading>
         <Paragraph>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ut labore.</Paragraph>
       </Card>

--- a/src/app/amsterdam/layout.tsx
+++ b/src/app/amsterdam/layout.tsx
@@ -175,7 +175,7 @@ export default function Amsterdam({ children }) {
               <Header.MenuLink fixed>Zoeken</Header.MenuLink>
             </NextLink>,
           ]}
-          logoLink={`${process.env.basePath}amsterdam`} // TODO: je kunt hier geen Next Link gebruiken
+          logoLink={`${process.env.basePath}amsterdam`} // TODO: je kunt hier geen NextLink gebruiken
           logoLinkTitle="Naar de homepage van gemeente Amsterdam"
         >
           <Grid paddingBottom="large" paddingTop="small">
@@ -196,9 +196,9 @@ export default function Amsterdam({ children }) {
               <div className="ams-mega-menu__columns">
                 <LinkList>
                   {megaMenuLinks.map(({ href, label }) => (
-                    <LinkList.Link href={href} key={label}>
-                      {label}
-                    </LinkList.Link>
+                    <NextLink href={href} key={label} legacyBehavior passHref>
+                      <LinkList.Link>{label}</LinkList.Link>
+                    </NextLink>
                   ))}
                 </LinkList>
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Grid, Heading, LinkList, PageHeading, Paragraph, Screen } from '@amsterdam/design-system-react'
-import Link from 'next/link'
+import NextLink from 'next/link'
 
 export default function Page() {
   return (
@@ -15,15 +15,15 @@ export default function Page() {
         </Grid.Cell>
         <Grid.Cell span="all">
           <LinkList>
-            <Link href="/amopis" legacyBehavior passHref>
+            <NextLink href="/amopis" legacyBehavior passHref>
               <LinkList.Link>Amopis</LinkList.Link>
-            </Link>
-            <Link href="/amsterdam" legacyBehavior passHref>
+            </NextLink>
+            <NextLink href="/amsterdam" legacyBehavior passHref>
               <LinkList.Link>Amsterdam</LinkList.Link>
-            </Link>
-            <Link href="/signalen" legacyBehavior passHref>
+            </NextLink>
+            <NextLink href="/signalen" legacyBehavior passHref>
               <LinkList.Link>Signalen</LinkList.Link>
-            </Link>
+            </NextLink>
             {/* Append route import here */}
           </LinkList>
         </Grid.Cell>

--- a/src/app/signalen/_components/BackLink/BackLink.tsx
+++ b/src/app/signalen/_components/BackLink/BackLink.tsx
@@ -9,7 +9,7 @@ import { Icon } from '@amsterdam/design-system-react'
 import { ChevronLeftIcon } from '@amsterdam/design-system-react-icons'
 import { forwardRef } from 'react'
 import type { AnchorHTMLAttributes, ForwardedRef } from 'react'
-import Link from 'next/link'
+import NextLink from 'next/link'
 
 import './back-link.css'
 
@@ -17,10 +17,10 @@ export type BackLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'place
 
 export const BackLink = forwardRef(
   ({ children, className, href, ...otherProps }: BackLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
-    <Link {...otherProps} className={`ams-back-link ${className}`} href={href} ref={ref}>
+    <NextLink {...otherProps} className={`ams-back-link ${className}`} href={href} ref={ref}>
       <Icon svg={ChevronLeftIcon} size="level-6" />
       {children}
-    </Link>
+    </NextLink>
   ),
 )
 

--- a/src/app/signalen/contact-2/page.tsx
+++ b/src/app/signalen/contact-2/page.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { Button, Checkbox, Column, FieldSet, Grid, Heading, Paragraph } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { useEffect } from 'react'
@@ -32,9 +33,9 @@ function Contact2() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <BackLink className="ams-mb--xs" href="/signalen/contact-1">
-          Vorige vraag
-        </BackLink>
+        <NextLink href="/signalen/contact-1" legacyBehavior passHref>
+          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
+        </NextLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/contact-2/page.tsx
+++ b/src/app/signalen/contact-2/page.tsx
@@ -33,9 +33,9 @@ function Contact2() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <NextLink href="/signalen/contact-1" legacyBehavior passHref>
-          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
-        </NextLink>
+        <BackLink className="ams-mb--xs" href="/signalen/contact-1">
+          Vorige vraag
+        </BackLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/documenten/page.tsx
+++ b/src/app/signalen/documenten/page.tsx
@@ -43,9 +43,9 @@ function Docs() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <NextLink href="/signalen/contact-1" legacyBehavior passHref>
-          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
-        </NextLink>
+        <BackLink className="ams-mb--xs" href="/signalen/contact-1">
+          Vorige vraag
+        </BackLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/documenten/page.tsx
+++ b/src/app/signalen/documenten/page.tsx
@@ -13,6 +13,7 @@ import {
   Paragraph,
   UnorderedList,
 } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { useEffect } from 'react'
@@ -42,9 +43,9 @@ function Docs() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <BackLink className="ams-mb--xs" href="/signalen/contact-2">
-          Vorige vraag
-        </BackLink>
+        <NextLink href="/signalen/contact-1" legacyBehavior passHref>
+          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
+        </NextLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/layout.tsx
+++ b/src/app/signalen/layout.tsx
@@ -24,7 +24,7 @@ function Signalen({ children }) {
         <Grid.Cell span="all">
           <SkipLink href="#main">Direct naar inhoud</SkipLink>
           <Header
-            logoLink={`${process.env.basePath}signalen`} // TODO: je kunt hier geen Next Link gebruiken
+            logoLink={`${process.env.basePath}signalen`} // TODO: je kunt hier geen NextLink gebruiken
             logoLinkTitle="Naar de homepage van Signalen Amsterdam"
           />
         </Grid.Cell>

--- a/src/app/signalen/samenvatting/page.tsx
+++ b/src/app/signalen/samenvatting/page.tsx
@@ -100,9 +100,9 @@ function Summary() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 9 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <BackLink className="ams-mb--xs" href="/signalen/documenten">
-          Vorige vraag
-        </BackLink>
+        <NextLink href="/signalen/documenten" legacyBehavior passHref>
+          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
+        </NextLink>
         <Column>
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/samenvatting/page.tsx
+++ b/src/app/signalen/samenvatting/page.tsx
@@ -100,9 +100,9 @@ function Summary() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 9 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <NextLink href="/signalen/documenten" legacyBehavior passHref>
-          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
-        </NextLink>
+        <BackLink className="ams-mb--xs" href="/signalen/documenten">
+          Vorige vraag
+        </BackLink>
         <Column>
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-1/page.tsx
+++ b/src/app/signalen/vul-aan-1/page.tsx
@@ -33,9 +33,9 @@ function VulAan1() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <NextLink href="/signalen" legacyBehavior passHref>
-          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
-        </NextLink>
+        <BackLink className="ams-mb--xs" href="/signalen">
+          Vorige vraag
+        </BackLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-1/page.tsx
+++ b/src/app/signalen/vul-aan-1/page.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { Button, Column, FieldSet, Grid, Heading, Paragraph, Radio } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { useEffect } from 'react'
@@ -32,9 +33,9 @@ function VulAan1() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <BackLink className="ams-mb--xs" href="/signalen">
-          Vorige vraag
-        </BackLink>
+        <NextLink href="/signalen" legacyBehavior passHref>
+          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
+        </NextLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-1b/page.tsx
+++ b/src/app/signalen/vul-aan-1b/page.tsx
@@ -41,9 +41,9 @@ function VulAan1() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <NextLink href="/signalen/vul-aan-1" legacyBehavior passHref>
-          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
-        </NextLink>
+        <BackLink className="ams-mb--xs" href="/signalen/vul-aan-1">
+          Vorige vraag
+        </BackLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-1b/page.tsx
+++ b/src/app/signalen/vul-aan-1b/page.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { Button, Column, FieldSet, Grid, Heading, Paragraph, Radio } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { useEffect } from 'react'
@@ -40,9 +41,9 @@ function VulAan1() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <BackLink className="ams-mb--xs" href="/signalen/vul-aan-1">
-          Vorige vraag
-        </BackLink>
+        <NextLink href="/signalen/vul-aan-1" legacyBehavior passHref>
+          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
+        </NextLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-1c/page.tsx
+++ b/src/app/signalen/vul-aan-1c/page.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { Button, Column, Field, Grid, Heading, Label, Paragraph, TimeInput } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { useEffect } from 'react'
@@ -32,9 +33,9 @@ function VulAan1() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <BackLink className="ams-mb--xs" href="/signalen/vul-aan-1b">
-          Vorige vraag
-        </BackLink>
+        <NextLink href="/signalen/vul-aan-1b" legacyBehavior passHref>
+          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
+        </NextLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-1c/page.tsx
+++ b/src/app/signalen/vul-aan-1c/page.tsx
@@ -33,9 +33,9 @@ function VulAan1() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <NextLink href="/signalen/vul-aan-1b" legacyBehavior passHref>
-          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
-        </NextLink>
+        <BackLink className="ams-mb--xs" href="/signalen/vul-aan-1b">
+          Vorige vraag
+        </BackLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-2/page.tsx
+++ b/src/app/signalen/vul-aan-2/page.tsx
@@ -33,13 +33,12 @@ function VulAan2() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <NextLink
+        <BackLink
+          className="ams-mb--xs"
           href={formData.when === 'eerder' ? '/signalen/vul-aan-1c' : '/signalen/vul-aan-1'}
-          legacyBehavior
-          passHref
         >
-          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
-        </NextLink>
+          Vorige vraag
+        </BackLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-2/page.tsx
+++ b/src/app/signalen/vul-aan-2/page.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { Button, Column, Field, Grid, Heading, Label, Paragraph, TextArea } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { useEffect } from 'react'
@@ -32,12 +33,13 @@ function VulAan2() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <BackLink
-          className="ams-mb--xs"
+        <NextLink
           href={formData.when === 'eerder' ? '/signalen/vul-aan-1c' : '/signalen/vul-aan-1'}
+          legacyBehavior
+          passHref
         >
-          Vorige vraag
-        </BackLink>
+          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
+        </NextLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-3/page.tsx
+++ b/src/app/signalen/vul-aan-3/page.tsx
@@ -50,9 +50,9 @@ function VulAan3() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <NextLink href="/signalen/vul-aan-2" legacyBehavior passHref>
-          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
-        </NextLink>
+        <BackLink className="ams-mb--xs" href="/signalen/vul-aan-2">
+          Vorige vraag
+        </BackLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">

--- a/src/app/signalen/vul-aan-3/page.tsx
+++ b/src/app/signalen/vul-aan-3/page.tsx
@@ -13,6 +13,7 @@ import {
   Paragraph,
   Radio,
 } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { useEffect } from 'react'
@@ -49,9 +50,9 @@ function VulAan3() {
   return (
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
-        <BackLink className="ams-mb--xs" href="/signalen/vul-aan-2">
-          Vorige vraag
-        </BackLink>
+        <NextLink href="/signalen/vul-aan-2" legacyBehavior passHref>
+          <BackLink className="ams-mb--xs">Vorige vraag</BackLink>
+        </NextLink>
         <Column className="ams-mb--md">
           <Heading>Melding openbare ruimte</Heading>
           <hgroup className="ams-gap--xs">


### PR DESCRIPTION
It appeared there were quite a few links that weren’t wrapped in Next Links.