### PR TITLE
chore: Configure reasonable browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,9 @@
     "node-plop": {
       "inquirer": "9.3.5"
     }
-  }
+  },
+  "browserslist": [
+    "defaults and fully supports es6-module",
+    "maintained node versions"
+  ]
 }


### PR DESCRIPTION
This prevents an obsolete warning from autoprefixer about the ‘start’ value having mixed support and considering using ‘flex-start’ instead.

> Autoprefixer, Babel and many other tools will find target browsers automatically if you add the following to package.json: – source: https://browsersl.ist