### PR TITLE
Add prototype for a form to make an appointment

### DIFF
--- a/src/app/afspraak-maken/bedankt/page.tsx
+++ b/src/app/afspraak-maken/bedankt/page.tsx
@@ -26,7 +26,7 @@ export default function Bedankt() {
           U heeft een afspraak gemaakt. Wij sturen een e-mail met de gegevens van uw afspraak naar{' '}
           <Link href="#">micah@live.nl</Link>. U krijgt van ons een e-mail met de gegevens van uw afspraak.
         </Paragraph>
-        <Heading className="ams-mb-xs" level={2} size="level-4">
+        <Heading className="ams-mb-xs" level={2} size="level-3">
           Neem dit mee naar uw afspraak
         </Heading>
         <UnorderedList className="ams-mb-l">

--- a/src/app/afspraak-maken/bedankt/page.tsx
+++ b/src/app/afspraak-maken/bedankt/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import {
+  Accordion,
+  ActionGroup,
+  Button,
+  Column,
+  Grid,
+  Heading,
+  Link,
+  Paragraph,
+  Row,
+  StandaloneLink,
+  UnorderedList,
+} from '@amsterdam/design-system-react'
+import { ChevronBackwardIcon, ChevronForwardIcon, DownloadIcon } from '@amsterdam/design-system-react-icons'
+
+export default function Bedankt() {
+  return (
+    <Grid paddingBottom="2x-large" paddingTop="large">
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
+        <Heading className="ams-mb-xl" level={1}>
+          Bedankt
+        </Heading>
+        <Paragraph className="ams-mb-m">
+          U heeft een afspraak gemaakt. Wij sturen een e-mail met de gegevens van uw afspraak naar{' '}
+          <Link href="#">micah@live.nl</Link>. U krijgt van ons een e-mail met de gegevens van uw afspraak.
+        </Paragraph>
+        <Heading className="ams-mb-xs" level={2} size="level-4">
+          Neem dit mee naar uw afspraak
+        </Heading>
+        <UnorderedList className="ams-mb-l">
+          <UnorderedList.Item>Bewijs van verlies document</UnorderedList.Item>
+        </UnorderedList>
+        <div>
+          <StandaloneLink className="ams-mb-l" download href="#" icon={DownloadIcon}>
+            Download overzicht afspraak PDF, 1MB
+          </StandaloneLink>
+        </div>
+        <StandaloneLink href="/afspraak-maken">Sluit het formulier</StandaloneLink>
+      </Grid.Cell>
+    </Grid>
+  )
+}

--- a/src/app/afspraak-maken/controleer/page.tsx
+++ b/src/app/afspraak-maken/controleer/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import {
+  Accordion,
+  ActionGroup,
+  Button,
+  Column,
+  Grid,
+  Heading,
+  Paragraph,
+  Row,
+  StandaloneLink,
+} from '@amsterdam/design-system-react'
+import { ChevronBackwardIcon, ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
+
+type ReviewItem = {
+  label: string
+  shortLabel: string
+  value: string
+}
+
+const reviewItems: Array<Array<ReviewItem>> = [
+  [
+    {
+      label: 'Kies het onderwerp van uw afspraak',
+      shortLabel: 'onderwerp',
+      value: 'Paspoort / ID / Rijbewijs',
+    },
+    {
+      label: 'Kies waar het over gaat',
+      shortLabel: 'product',
+      value: 'Paspoort vernieuwen',
+    },
+    {
+      label: 'Voor hoeveel personen wilt u een paspoort aanvragen?',
+      shortLabel: 'aantal personen',
+      value: '2',
+    },
+    {
+      label: 'Is er iemand bij de afspraak die hulpmiddelen nodig heeft?',
+      shortLabel: 'hulpmiddelen',
+      value: 'Nee',
+    },
+    {
+      label: 'Locatie',
+      shortLabel: 'locatie',
+      value: 'Stadsloket Centrum Amstel 1, 1011 PN Amsterdam',
+    },
+    {
+      label: 'Datum',
+      shortLabel: 'datum',
+      value: 'dag 23 mei 2025',
+    },
+    {
+      label: 'Tijd',
+      shortLabel: 'tijd',
+      value: '09.00 uur',
+    },
+  ],
+  [
+    {
+      label: 'Voornaam',
+      shortLabel: 'voornaam',
+      value: 'Sarah',
+    },
+    {
+      label: 'Achternaam',
+      shortLabel: 'achternaam',
+      value: 'Tulpent',
+    },
+    {
+      label: 'Geboortedatum',
+      shortLabel: 'geboortedatum',
+      value: '8 september 1995',
+    },
+    {
+      label: 'E-mailadres',
+      shortLabel: 'e-mailadres',
+      value: 'sarah@live.nl',
+    },
+    {
+      label: 'Telefoonnummer',
+      shortLabel: 'telefoonnummer',
+      value: '06 1648 4127',
+    },
+  ],
+]
+
+function ReviewItem({ label, shortLabel, value }: ReviewItem) {
+  return (
+    <Row>
+      <div style={{ flexBasis: '50%' }}>
+        <Heading level={3} size="level-5">
+          {label}
+        </Heading>
+        <Paragraph>{value}</Paragraph>
+      </div>
+      <StandaloneLink href="#">Wijzig {shortLabel}</StandaloneLink>
+    </Row>
+  )
+}
+
+export default function Controleer() {
+  return (
+    <Grid paddingBottom="2x-large" paddingTop="large">
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
+        <Heading level={1}>Afspraak maken</Heading>
+        <Paragraph className="ams-mb-xl">Stap 3 van 3: Controleer</Paragraph>
+        <Paragraph className="ams-mb-xl">
+          Controleer de gegevens die u heeft ingevuld. U kunt daarna uw afspraak bevestigen.
+        </Paragraph>
+        <Accordion className="ams-mb-xl" headingLevel={2}>
+          <Accordion.Section expanded label="Controleer stap 1">
+            <Column>
+              {reviewItems[0].map(({ label, shortLabel, value }) => (
+                <ReviewItem label={label} shortLabel={shortLabel} value={value} />
+              ))}
+            </Column>
+          </Accordion.Section>
+          <Accordion.Section expanded label="Controleer stap 2">
+            <Column>
+              {reviewItems[1].map(({ label, shortLabel, value }) => (
+                <ReviewItem label={label} shortLabel={shortLabel} value={value} />
+              ))}
+            </Column>
+          </Accordion.Section>
+        </Accordion>
+        <form>
+          <ActionGroup className="ams-mb-m">
+            <Button
+              formAction="/afspraak-maken/wie"
+              icon={ChevronBackwardIcon}
+              iconBefore
+              type="submit"
+              variant="secondary"
+            >
+              Vorige vraag
+            </Button>
+            <Button icon={ChevronForwardIcon} type="submit" variant="primary">
+              Afspraak bevestigen
+            </Button>
+          </ActionGroup>
+          <Button type="submit" variant="tertiary">
+            Opslaan en later verder
+          </Button>
+        </form>
+      </Grid.Cell>
+    </Grid>
+  )
+}

--- a/src/app/afspraak-maken/controleer/page.tsx
+++ b/src/app/afspraak-maken/controleer/page.tsx
@@ -125,7 +125,7 @@ export default function Controleer() {
             </Column>
           </Accordion.Section>
         </Accordion>
-        <form>
+        <form action="/afspraak-maken/bedankt" method="post">
           <ActionGroup className="ams-mb-m">
             <Button
               formAction="/afspraak-maken/wie"

--- a/src/app/afspraak-maken/hoeveel/page.tsx
+++ b/src/app/afspraak-maken/hoeveel/page.tsx
@@ -13,29 +13,27 @@ import {
 } from '@amsterdam/design-system-react'
 import { ChevronBackwardIcon, ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
 
-const waaroverOptions = ['Paspoort aanvragen', 'Paspoor vermist of gestolen', 'Paspoort ophalen']
-
-export default function Waarover() {
+export default function Hoeveel() {
   return (
     <Grid paddingBottom="2x-large" paddingTop="large">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
         <Heading level={1}>Afspraak maken</Heading>
         <Paragraph className="ams-mb-xl">Stap 1 van 3: Afspraak</Paragraph>
-        <form action="/afspraak-maken/hoeveel" method="post">
+        <form>
           <Field className="ams-mb-xl">
-            <Label htmlFor="waarover">Kies waar het over gaat</Label>
-            <Select id="waarover">
-              <Select.Option value="">-- Kies een onderwerp --</Select.Option>
-              {waaroverOptions.map((label, index) => (
+            <Label htmlFor="hoeveel">Voor hoeveel personen wilt u een paspoort aanvragen?</Label>
+            <Select id="hoeveel">
+              <Select.Option value="">-- Kies aantal personen --</Select.Option>
+              {Array.from(Array(5).keys()).map((label, index) => (
                 <Select.Option key={index} value={index + 1}>
-                  {label}
+                  {label + 1}
                 </Select.Option>
               ))}
             </Select>
           </Field>
           <ActionGroup className="ams-mb-m">
             <Button
-              formAction="/afspraak-maken/waarvoor"
+              formAction="/afspraak-maken/waarover"
               icon={ChevronBackwardIcon}
               iconBefore
               type="submit"

--- a/src/app/afspraak-maken/layout.tsx
+++ b/src/app/afspraak-maken/layout.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { Grid, Heading, LinkList, Page, PageFooter, PageHeader, Paragraph, SkipLink } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
+
+export default function AfspraakMaken({ children }) {
+  return (
+    <Page className="ams-theme">
+      <Grid>
+        <Grid.Cell span="all">
+          <SkipLink href="#main">Direct naar inhoud</SkipLink>
+        </Grid.Cell>
+      </Grid>
+      <PageHeader
+        logoLink={`${process.env.basePath}afspraak-maken`}
+        logoLinkTitle="Naar de homepage van Afspraak maken"
+      />
+      <main id="main">{children}</main>
+      <PageFooter>
+        <PageFooter.Spotlight>
+          <Grid gapVertical="2x-large" paddingVertical="x-large">
+            <Grid.Cell span="all">
+              <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
+                Koptekst
+              </Heading>
+              <Paragraph className="ams-mb-m" color="inverse" size="small">
+                Paragraaf.
+              </Paragraph>
+              <LinkList>
+                <LinkList.Link color="inverse" href="#" size="small">
+                  Link 1
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#" size="small">
+                  Link 2
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#" size="small">
+                  Link 3
+                </LinkList.Link>
+              </LinkList>
+            </Grid.Cell>
+          </Grid>
+        </PageFooter.Spotlight>
+        <Heading className="ams-visually-hidden" level={2}>
+          Over deze website
+        </Heading>
+        <PageFooter.Menu>
+          <NextLink href="/" legacyBehavior passHref>
+            <PageFooter.MenuLink>Prototypes</PageFooter.MenuLink>
+          </NextLink>
+          <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>
+          <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
+          <PageFooter.MenuLink href="#">Toegankelijkheid</PageFooter.MenuLink>
+          {/* Append Pagefooter link here */}
+        </PageFooter.Menu>
+      </PageFooter>
+    </Page>
+  )
+}

--- a/src/app/afspraak-maken/layout.tsx
+++ b/src/app/afspraak-maken/layout.tsx
@@ -52,7 +52,7 @@ export default function AfspraakMaken({ children }) {
         <PageFooter.Spotlight>
           <Grid gapVertical="2x-large" paddingVertical="x-large">
             <Grid.Cell span="all">
-              <Heading className="ams-mb-m" color="inverse" level={2} size="level-4">
+              <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">
                 Vragen over dit formulier
               </Heading>
               <LinkList>

--- a/src/app/afspraak-maken/layout.tsx
+++ b/src/app/afspraak-maken/layout.tsx
@@ -1,6 +1,16 @@
 'use client'
 
-import { Grid, Heading, LinkList, Page, PageFooter, PageHeader, Paragraph, SkipLink } from '@amsterdam/design-system-react'
+import {
+  Grid,
+  Heading,
+  LinkList,
+  Page,
+  PageFooter,
+  PageHeader,
+  Paragraph,
+  SkipLink,
+} from '@amsterdam/design-system-react'
+import { DocumentIcon, MailIcon, PhoneIcon } from '@amsterdam/design-system-react-icons'
 import NextLink from 'next/link'
 
 export default function AfspraakMaken({ children }) {
@@ -14,35 +24,51 @@ export default function AfspraakMaken({ children }) {
       <PageHeader
         logoLink={`${process.env.basePath}afspraak-maken`}
         logoLinkTitle="Naar de homepage van Afspraak maken"
-      />
+        menuItems={[
+          <PageHeader.MenuLink href="#" key={1} lang="en">
+            English
+          </PageHeader.MenuLink>,
+          <PageHeader.MenuLink href="#" key={2}>
+            Mijn Amsterdam
+          </PageHeader.MenuLink>,
+        ]}
+        noMenuButtonOnWideWindow
+      >
+        <Grid paddingBottom="2x-large" paddingTop="large">
+          <PageHeader.GridCellNarrowWindowOnly span="all">
+            <LinkList>
+              <LinkList.Link href="https://mijn.amsterdam.nl/" rel="external">
+                Mijn Amsterdam
+              </LinkList.Link>
+              <LinkList.Link href="#" lang="en">
+                English
+              </LinkList.Link>
+            </LinkList>
+          </PageHeader.GridCellNarrowWindowOnly>
+        </Grid>
+      </PageHeader>
       <main id="main">{children}</main>
       <PageFooter>
         <PageFooter.Spotlight>
           <Grid gapVertical="2x-large" paddingVertical="x-large">
             <Grid.Cell span="all">
-              <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
-                Koptekst
+              <Heading className="ams-mb-m" color="inverse" level={2} size="level-4">
+                Vragen over dit formulier
               </Heading>
-              <Paragraph className="ams-mb-m" color="inverse" size="small">
-                Paragraaf.
-              </Paragraph>
               <LinkList>
-                <LinkList.Link color="inverse" href="#" size="small">
-                  Link 1
+                <LinkList.Link color="inverse" href="#" icon={DocumentIcon}>
+                  Lees alle informatie op amsterdam.nl/product
                 </LinkList.Link>
-                <LinkList.Link color="inverse" href="#" size="small">
-                  Link 2
+                <LinkList.Link color="inverse" href="#" icon={PhoneIcon}>
+                  Bel 14 020
                 </LinkList.Link>
-                <LinkList.Link color="inverse" href="#" size="small">
-                  Link 3
+                <LinkList.Link color="inverse" href="#" icon={MailIcon}>
+                  Contact
                 </LinkList.Link>
               </LinkList>
             </Grid.Cell>
           </Grid>
         </PageFooter.Spotlight>
-        <Heading className="ams-visually-hidden" level={2}>
-          Over deze website
-        </Heading>
         <PageFooter.Menu>
           <NextLink href="/" legacyBehavior passHref>
             <PageFooter.MenuLink>Prototypes</PageFooter.MenuLink>
@@ -50,7 +76,6 @@ export default function AfspraakMaken({ children }) {
           <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>
           <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
           <PageFooter.MenuLink href="#">Toegankelijkheid</PageFooter.MenuLink>
-          {/* Append Pagefooter link here */}
         </PageFooter.Menu>
       </PageFooter>
     </Page>

--- a/src/app/afspraak-maken/page.tsx
+++ b/src/app/afspraak-maken/page.tsx
@@ -1,13 +1,39 @@
 'use client'
 
-import { Grid, Heading, Paragraph } from '@amsterdam/design-system-react'
+import { Grid, Heading, OrderedList, Paragraph, StandaloneLink } from '@amsterdam/design-system-react'
+import { ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
 
-export default function HomePage() {
+export default function Introductie() {
   return (
-    <Grid paddingBottom="x-large">
-      <Grid.Cell span="all">
-        <Heading level={1}>Afspraak maken</Heading>
-        <Paragraph>Hallo nieuw prototype</Paragraph>
+    <Grid paddingBottom="2x-large" paddingTop="large">
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
+        <Heading className="ams-mb-xl" level={1}>
+          Afspraak maken
+        </Heading>
+        <Heading className="ams-mb-s" level={2}>
+          Waar u dit formulier voor gebruikt
+        </Heading>
+        <Paragraph className="ams-mb-xl">
+          Met dit formulier maakt u een afspraak bij een Stadsloket in Amsterdam of Weesp.
+        </Paragraph>
+        <Heading className="ams-mb-s" level={2}>
+          De stappen in dit formulier
+        </Heading>
+        <OrderedList className="ams-mb-xl">
+          <OrderedList.Item>
+            <strong>Afspraak</strong> – Kies waarvoor u een afspraak wilt maken. Kies ook waar u de afspraak wilt
+            hebben. En wanneer.
+          </OrderedList.Item>
+          <OrderedList.Item>
+            <strong>Uw gegevens</strong> – Vul uw contactgegevens in.
+          </OrderedList.Item>
+          <OrderedList.Item>
+            <strong>Bevestiging</strong> – Controleer de gegevens die u heeft ingevuld. Verstuur de aanvraag.
+          </OrderedList.Item>
+        </OrderedList>
+        <StandaloneLink href="#" icon={ChevronForwardIcon}>
+          Start het formulier
+        </StandaloneLink>
       </Grid.Cell>
     </Grid>
   )

--- a/src/app/afspraak-maken/page.tsx
+++ b/src/app/afspraak-maken/page.tsx
@@ -11,13 +11,13 @@ export default function Introductie() {
         <Heading className="ams-mb-xl" level={1}>
           Afspraak maken
         </Heading>
-        <Heading className="ams-mb-s" level={2}>
+        <Heading className="ams-mb-xs" level={2} size="level-3">
           Waar u dit formulier voor gebruikt
         </Heading>
         <Paragraph className="ams-mb-xl">
           Met dit formulier maakt u een afspraak bij een Stadsloket in Amsterdam of Weesp.
         </Paragraph>
-        <Heading className="ams-mb-s" level={2}>
+        <Heading className="ams-mb-xs" level={2} size="level-3">
           De stappen in dit formulier
         </Heading>
         <OrderedList className="ams-mb-xl">

--- a/src/app/afspraak-maken/page.tsx
+++ b/src/app/afspraak-maken/page.tsx
@@ -2,6 +2,7 @@
 
 import { Grid, Heading, OrderedList, Paragraph, StandaloneLink } from '@amsterdam/design-system-react'
 import { ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
+import NextLink from 'next/link'
 
 export default function Introductie() {
   return (
@@ -31,9 +32,9 @@ export default function Introductie() {
             <strong>Bevestiging</strong> – Controleer de gegevens die u heeft ingevuld. Verstuur de aanvraag.
           </OrderedList.Item>
         </OrderedList>
-        <StandaloneLink href="#" icon={ChevronForwardIcon}>
-          Start het formulier
-        </StandaloneLink>
+        <NextLink href="afspraak-maken/waarvoor" legacyBehavior passHref>
+          <StandaloneLink icon={ChevronForwardIcon}>Start het formulier</StandaloneLink>
+        </NextLink>
       </Grid.Cell>
     </Grid>
   )

--- a/src/app/afspraak-maken/page.tsx
+++ b/src/app/afspraak-maken/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { Grid, Heading, Paragraph } from '@amsterdam/design-system-react'
+
+export default function HomePage() {
+  return (
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span="all">
+        <Heading level={1}>Afspraak maken</Heading>
+        <Paragraph>Hallo nieuw prototype</Paragraph>
+      </Grid.Cell>
+    </Grid>
+  )
+}

--- a/src/app/afspraak-maken/waar/page.tsx
+++ b/src/app/afspraak-maken/waar/page.tsx
@@ -23,7 +23,7 @@ export default function Waar() {
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
         <Heading level={1}>Afspraak maken</Heading>
         <Paragraph className="ams-mb-xl">Stap 1 van 3: Afspraak</Paragraph>
-        <form>
+        <form action="/afspraak-maken/wie" method="post">
           <Field className="ams-mb-l">
             <Label htmlFor="waar">Stadsloket</Label>
             <Select id="waar">

--- a/src/app/afspraak-maken/waar/page.tsx
+++ b/src/app/afspraak-maken/waar/page.tsx
@@ -3,6 +3,7 @@
 import {
   ActionGroup,
   Button,
+  DateInput,
   Field,
   Grid,
   Heading,
@@ -10,30 +11,41 @@ import {
   Paragraph,
   Select,
   StandaloneLink,
+  TimeInput,
 } from '@amsterdam/design-system-react'
 import { ChevronBackwardIcon, ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
 
-export default function Hoeveel() {
+const waarOptions = ['Centrum', 'Nieuw-West', 'Noord', 'Oost', 'West', 'Zuid', 'Zuidoost', 'Weesp']
+
+export default function Waar() {
   return (
     <Grid paddingBottom="2x-large" paddingTop="large">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
         <Heading level={1}>Afspraak maken</Heading>
         <Paragraph className="ams-mb-xl">Stap 1 van 3: Afspraak</Paragraph>
-        <form action="/afspraak-maken/waar" method="post">
-          <Field className="ams-mb-xl">
-            <Label htmlFor="hoeveel">Voor hoeveel personen wilt u een paspoort aanvragen?</Label>
-            <Select id="hoeveel">
-              <Select.Option value="">-- Kies aantal personen --</Select.Option>
-              {Array.from(Array(5).keys()).map((label, index) => (
+        <form>
+          <Field className="ams-mb-l">
+            <Label htmlFor="waar">Stadsloket</Label>
+            <Select id="waar">
+              <Select.Option value="">-- Kies een stadsloket --</Select.Option>
+              {waarOptions.map((label, index) => (
                 <Select.Option key={index} value={index + 1}>
-                  {label + 1}
+                  {label}
                 </Select.Option>
               ))}
             </Select>
           </Field>
+          <Field className="ams-mb-l">
+            <Label htmlFor="datum">Datum</Label>
+            <DateInput id="datum" />
+          </Field>
+          <Field className="ams-mb-xl">
+            <Label htmlFor="tijd">Tijd</Label>
+            <TimeInput id="tijd" />
+          </Field>
           <ActionGroup className="ams-mb-m">
             <Button
-              formAction="/afspraak-maken/waarover"
+              formAction="/afspraak-maken/hoeveel"
               icon={ChevronBackwardIcon}
               iconBefore
               type="submit"

--- a/src/app/afspraak-maken/waarover/page.tsx
+++ b/src/app/afspraak-maken/waarover/page.tsx
@@ -13,29 +13,20 @@ import {
 } from '@amsterdam/design-system-react'
 import { ChevronBackwardIcon, ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
 
-const waarvoorOptions = [
-  'Paspoort',
-  'Identiteitskaart',
-  'Rijbewijs',
-  'Vluchtelingenpaspoort',
-  'Uw gegevens wijzigen',
-  'Verhuizen en adresgegevens',
-  'Parkeren',
-  'Sociaal Loket',
-]
+const waaroverOptions = ['Paspoort aanvragen', 'Paspoor vermist of gestolen', 'Paspoort ophalen']
 
-export default function Waarvoor() {
+export default function Waarover() {
   return (
     <Grid paddingBottom="2x-large" paddingTop="large">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
         <Heading level={1}>Afspraak maken</Heading>
         <Paragraph className="ams-mb-xl">Stap 1 van 3: Afspraak</Paragraph>
-        <form action="/afspraak-maken/waarover" method="post">
+        <form>
           <Field className="ams-mb-xl">
-            <Label htmlFor="waarvoor">Kies waar u voor wilt langskomen op het Stadsloket</Label>
-            <Select id="waarvoor">
+            <Label htmlFor="waarover">Kies waar het over gaat</Label>
+            <Select id="waarover">
               <Select.Option value="">-- Kies een onderwerp --</Select.Option>
-              {waarvoorOptions.map((label, index) => (
+              {waaroverOptions.map((label, index) => (
                 <Select.Option key={index} value={index + 1}>
                   {label}
                 </Select.Option>
@@ -43,9 +34,15 @@ export default function Waarvoor() {
             </Select>
           </Field>
           <ActionGroup className="ams-mb-m">
-            <StandaloneLink href="/afspraak-maken" icon={ChevronBackwardIcon}>
-              Terug naar de inleiding
-            </StandaloneLink>
+            <Button
+              formAction="/afspraak-maken/waarvoor"
+              icon={ChevronBackwardIcon}
+              iconBefore
+              type="submit"
+              variant="secondary"
+            >
+              Vorige vraag
+            </Button>
             <Button icon={ChevronForwardIcon} type="submit" variant="primary">
               Volgende vraag
             </Button>

--- a/src/app/afspraak-maken/waarvoor/page.tsx
+++ b/src/app/afspraak-maken/waarvoor/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import {
+  ActionGroup,
+  Button,
+  Field,
+  Grid,
+  Heading,
+  Label,
+  Paragraph,
+  Select,
+  StandaloneLink,
+} from '@amsterdam/design-system-react'
+import { ChevronBackwardIcon, ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
+
+const waarvoorOptions = [
+  'Paspoort',
+  'Identiteitskaart',
+  'Rijbewijs',
+  'Vluchtelingenpaspoort',
+  'Uw gegevens wijzigen',
+  'Verhuizen en adresgegevens',
+  'Parkeren',
+  'Sociaal Loket',
+]
+
+export default function Waarvoor() {
+  return (
+    <Grid paddingBottom="2x-large" paddingTop="large">
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
+        <Heading level={1}>Afspraak maken</Heading>
+        <Paragraph className="ams-mb-xl">Stap 1 van 3: Afspraak</Paragraph>
+        <form>
+          <Field className="ams-mb-xl">
+            <Label htmlFor="waarvoor">Kies waar u voor wilt langskomen op het Stadsloket</Label>
+            <Select id="waarvoor">
+              <Select.Option value="">-- Kies een onderwerp --</Select.Option>
+              {waarvoorOptions.map((label, index) => (
+                <Select.Option key={index} value={index + 1}>
+                  {label}
+                </Select.Option>
+              ))}
+            </Select>
+          </Field>
+          <ActionGroup className="ams-mb-m">
+            <StandaloneLink href="/afspraak-maken" icon={ChevronBackwardIcon}>
+              Terug naar de inleiding
+            </StandaloneLink>
+            <Button icon={ChevronForwardIcon} type="submit" variant="primary">
+              Volgende vraag
+            </Button>
+          </ActionGroup>
+          <Button type="submit" variant="tertiary">
+            Opslaan en later verder
+          </Button>
+        </form>
+      </Grid.Cell>
+    </Grid>
+  )
+}

--- a/src/app/afspraak-maken/wie/page.tsx
+++ b/src/app/afspraak-maken/wie/page.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   DateInput,
   Field,
+  FieldSet,
   Grid,
   Heading,
   Label,
@@ -40,10 +41,22 @@ export default function Wie() {
             <Label htmlFor="family-name">Achternaam</Label>
             <TextInput autoComplete="family-name" id="family-name" size={24} />
           </Field>
-          <Field className="ams-mb-l">
-            <Label htmlFor="bday">Geboortedatum</Label>
-            <DateInput id="bday" />
-          </Field>
+          <FieldSet legend="Geboortedatum" className="ams-mb-l">
+            <Row wrap>
+              <Field>
+                <Label htmlFor="bday">Dag</Label>
+                <TextInput autoComplete="bday-day" id="bday-day" size={2} />
+              </Field>
+              <Field>
+                <Label htmlFor="bday">Maand</Label>
+                <TextInput autoComplete="bday-month" id="bday-month" size={2} />
+              </Field>
+              <Field>
+                <Label htmlFor="bday">Jaar</Label>
+                <TextInput autoComplete="bday-year" id="bday-year" size={4} />
+              </Field>
+            </Row>
+          </FieldSet>
           <Field className="ams-mb-l">
             <Label htmlFor="email">E-mailadres</Label>
             <TextInput autoComplete="email" autoCorrect="off" spellCheck="false" type="email" id="email" size={24} />

--- a/src/app/afspraak-maken/wie/page.tsx
+++ b/src/app/afspraak-maken/wie/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import {
+  ActionGroup,
+  Button,
+  DateInput,
+  Field,
+  Grid,
+  Heading,
+  Label,
+  Paragraph,
+  Row,
+  Select,
+  StandaloneLink,
+  TextInput,
+} from '@amsterdam/design-system-react'
+import { ChevronBackwardIcon, ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
+
+const telCountryCodeOptions = [
+  'Nederland (+31)',
+  'Bahama’s (+1242)',
+  'België (+32)',
+  'Duitsland (+49)',
+  'Falklandeilanden (+500)',
+  'Malawi (+265)',
+]
+
+export default function Wie() {
+  return (
+    <Grid paddingBottom="2x-large" paddingTop="large">
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
+        <Heading level={1}>Afspraak maken</Heading>
+        <Paragraph className="ams-mb-xl">Stap 2 van 3: Uw gegevens</Paragraph>
+        <form>
+          <Field className="ams-mb-l">
+            <Label htmlFor="given-name">Voornaam</Label>
+            <TextInput autoComplete="given-name" id="given-name" size={24} />
+          </Field>
+          <Field className="ams-mb-l">
+            <Label htmlFor="family-name">Achternaam</Label>
+            <TextInput autoComplete="family-name" id="family-name" size={24} />
+          </Field>
+          <Field className="ams-mb-l">
+            <Label htmlFor="bday">Geboortedatum</Label>
+            <DateInput id="bday" />
+          </Field>
+          <Field className="ams-mb-l">
+            <Label htmlFor="email">E-mailadres</Label>
+            <TextInput autoComplete="email" autoCorrect="off" spellCheck="false" type="email" id="email" size={24} />
+          </Field>
+          <Row className="ams-mb-xl" wrap>
+            <Field>
+              <Label htmlFor="tel-country-code">Landnummer</Label>
+              <Select id="tel-country-code">
+                {telCountryCodeOptions.map((label, index) => (
+                  <Select.Option key={index} value={index + 1}>
+                    {label}
+                  </Select.Option>
+                ))}
+              </Select>
+            </Field>
+            <Field>
+              <Label htmlFor="email">Telefoonnummer</Label>
+              <TextInput autoComplete="tel" type="tel" id="phone" size={24} />
+            </Field>
+          </Row>
+          <ActionGroup className="ams-mb-m">
+            <Button
+              formAction="/afspraak-maken/waar"
+              icon={ChevronBackwardIcon}
+              iconBefore
+              type="submit"
+              variant="secondary"
+            >
+              Vorige vraag
+            </Button>
+            <Button icon={ChevronForwardIcon} type="submit" variant="primary">
+              Volgende vraag
+            </Button>
+          </ActionGroup>
+          <Button type="submit" variant="tertiary">
+            Opslaan en later verder
+          </Button>
+        </form>
+      </Grid.Cell>
+    </Grid>
+  )
+}

--- a/src/app/afspraak-maken/wie/page.tsx
+++ b/src/app/afspraak-maken/wie/page.tsx
@@ -21,7 +21,7 @@ const telCountryCodeOptions = [
   'Bahama’s (+1242)',
   'België (+32)',
   'Duitsland (+49)',
-  'Falklandeilanden (+500)',
+  'Frankrijk (+33)',
   'Malawi (+265)',
 ]
 
@@ -31,7 +31,7 @@ export default function Wie() {
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 4 }}>
         <Heading level={1}>Afspraak maken</Heading>
         <Paragraph className="ams-mb-xl">Stap 2 van 3: Uw gegevens</Paragraph>
-        <form>
+        <form action="/afspraak-maken/controleer" method="post">
           <Field className="ams-mb-l">
             <Label htmlFor="given-name">Voornaam</Label>
             <TextInput autoComplete="given-name" id="given-name" size={24} />
@@ -75,7 +75,7 @@ export default function Wie() {
               Vorige vraag
             </Button>
             <Button icon={ChevronForwardIcon} type="submit" variant="primary">
-              Volgende vraag
+              Controleer uw invoer
             </Button>
           </ActionGroup>
           <Button type="submit" variant="tertiary">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,9 @@ export default function Signalen() {
               <LinkList.Link>Signalen</LinkList.Link>
             </NextLink>
             {/* Append route import here */}
+            <NextLink href="/afspraak-maken" legacyBehavior passHref>
+              <LinkList.Link>Afspraak maken</LinkList.Link>
+            </NextLink>
           </LinkList>
         </Grid.Cell>
         <Grid.Cell span="all">


### PR DESCRIPTION
Designers from Dienstverlening have designed a form to let people make an appointment. It’s on [this page in Figma](https://www.figma.com/design/CtMX67n2bhabdianmC9W2i/Afspraak-maken?node-id=4801-23465).

This implements it in the browser.

I’ve noted the following remarks:

1. Heading 1 must be used at the correct size
2. For Heading 2, I consistently used Size 4, which corresponds to Label and Accordion
3. But Review Item uses Heading Size 5? Or should that just be bold body text?
4. The difference between steps and pages still comes across as unclear
5. Column in the center, with 6 cells on wide and medium, 4 on narrow
6. Large whitespace between Fields + Medium padding-bottom on that column
7. Date of birth should be a Date Input Group, not a Date Input
8. Country code: country name first so it can be selected by typing a letter
9. In the Select, showing something different from the Options isn't possible; as a result, the 'Country code' field is longer and stacks more quickly
10. Autocomplete pattern added
11. On confirmation: why use Accordion instead of Headings?
12. And why is the value below the label? That scans less easily
13. Slightly different labels for buttons
14. Texts can sometimes be shorter
15. Custom Page Header: does the logo link to the introduction page? And then a link to amsterdam.nl in the Header Navigation?
16. Custom Page Header: what is shown in the Mega Menu?
