### PR TITLE
fix: Remove unused imports

### DIFF
--- a/src/app/amopis/layout.tsx
+++ b/src/app/amopis/layout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { Avatar, Column, Grid, Page, PageFooter, PageHeader, SkipLink } from '@amsterdam/design-system-react'
+import { Avatar, Column, Page, PageFooter, PageHeader, SkipLink } from '@amsterdam/design-system-react'
 import NextLink from 'next/link'
 import { Sidebar } from './_components/SideBar/SideBar'
 import '@amsterdam/design-system-tokens/dist/compact.theme.css'

--- a/src/app/amsterdam/layout.tsx
+++ b/src/app/amsterdam/layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Column, Grid, Heading, Link, LinkList, Page, PageFooter, Paragraph } from '@amsterdam/design-system-react'
+import { Grid, Heading, Link, LinkList, Page, PageFooter, Paragraph } from '@amsterdam/design-system-react'
 import {
   ClockIcon,
   FacebookIcon,

--- a/src/app/amsterdam/nieuws/page.tsx
+++ b/src/app/amsterdam/nieuws/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Breadcrumb, Column, Grid, Heading, Paragraph } from '@amsterdam/design-system-react'
+import { Breadcrumb, Grid, Heading, Paragraph } from '@amsterdam/design-system-react'
 import NextLink from 'next/link'
 import NextImage from 'next/image'
 import fatbikesImage from '../_assets/fatbikes.jpg'

--- a/src/app/amsterdam/page.tsx
+++ b/src/app/amsterdam/page.tsx
@@ -6,7 +6,6 @@ import {
   Column,
   Grid,
   Heading,
-  Link,
   Overlap,
   Paragraph,
   SearchField,
@@ -106,11 +105,7 @@ function HomePage() {
         </Grid>
       )}
       <Overlap>
-        <NextImage
-          alt=""
-          className="ams-image ams-aspect-ratio-16-5"
-          src={vindenImage}
-        />
+        <NextImage alt="" className="ams-image ams-aspect-ratio-16-5" src={vindenImage} />
         <Grid style={{ alignSelf: 'center' }}>
           <Grid.Cell span={{ medium: 6, narrow: 4, wide: 8 }} start={{ medium: 2, narrow: 1, wide: 3 }}>
             <SearchField onSubmit={() => {}}>

--- a/src/app/amsterdam/template.tsx
+++ b/src/app/amsterdam/template.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Grid, LinkList, Heading, PageHeader, SkipLink } from '@amsterdam/design-system-react'
+import { Grid, LinkList, PageHeader, SkipLink } from '@amsterdam/design-system-react'
 import NextLink from 'next/link'
 
 const megaMenuLinks = [


### PR DESCRIPTION
We didn’t spot these in earlier reviews, apparently.