### PR TITLE
fix: Remove explicit basepath from links

### DIFF
--- a/.plop/templates/SiteLayout.tsx.hbs
+++ b/.plop/templates/SiteLayout.tsx.hbs
@@ -12,7 +12,7 @@ export default function {{pascalCase name}}({ children }) {
         </Grid.Cell>
       </Grid>
       <PageHeader
-        logoLinkComponent={(props) => <NextLink {...props} href={`${process.env.basePath}{{kebabCase name}}`} />}
+        logoLinkComponent={(props) => <NextLink {...props} href="/{{kebabCase name}}" />}
         logoLinkTitle="Naar de homepage van {{titleCase name}}"
       />
       <main id="main">{children}</main>

--- a/src/app/afspraak-maken/layout.tsx
+++ b/src/app/afspraak-maken/layout.tsx
@@ -22,7 +22,7 @@ export default function AfspraakMaken({ children }) {
         </Grid.Cell>
       </Grid>
       <PageHeader
-        logoLink={`${process.env.basePath}afspraak-maken`}
+        logoLink="/afspraak-maken"
         logoLinkTitle="Naar de homepage van Afspraak maken"
         menuItems={[
           <PageHeader.MenuLink href="#" key={1} lang="en">

--- a/src/app/amopis/layout.tsx
+++ b/src/app/amopis/layout.tsx
@@ -17,7 +17,7 @@ function Amopis({ children }: { children: ReactNode }) {
           <Column gap="none">
             <PageHeader
               brandName="Amopis"
-              logoLinkComponent={(props) => <NextLink {...props} href={`${process.env.basePath}amopis`} />}
+              logoLinkComponent={(props) => <NextLink {...props} href="/amopis" />}
               logoLinkTitle="Naar de homepage van Amopis"
               menuItems={<Avatar label="KH" title="Goedemorgen Kees Herder" />}
             />

--- a/src/app/amsterdam/template.tsx
+++ b/src/app/amsterdam/template.tsx
@@ -36,7 +36,7 @@ function Template({ children }) {
         </Grid.Cell>
       </Grid>
       <PageHeader
-        logoLinkComponent={(props) => <NextLink {...props} href={`${process.env.basePath}amsterdam`} />}
+        logoLinkComponent={(props) => <NextLink {...props} href="/amsterdam" />}
         logoLinkTitle="Naar de homepage van gemeente Amsterdam"
         menuItems={[
           <PageHeader.MenuLink href="https://mijn.amsterdam.nl/" key={1} rel="external">

--- a/src/app/signalen/layout.tsx
+++ b/src/app/signalen/layout.tsx
@@ -23,7 +23,7 @@ function Signalen({ children }) {
         <Grid.Cell span="all">
           <SkipLink href="#main">Direct naar inhoud</SkipLink>
           <PageHeader
-            logoLinkComponent={(props) => <NextLink {...props} href={`${process.env.basePath}signalen`} />}
+            logoLinkComponent={(props) => <NextLink {...props} href="/signalen" />}
             logoLinkTitle="Naar de homepage van Signalen Amsterdam"
           />
         </Grid.Cell>


### PR DESCRIPTION
This resulted in suplicate paths like https://amsterdam.github.io/design-system-prototypes/design-system-prototypes/amsterdam