### PR TITLE
fix(deps): Revert bumping actions/upload-pages-artifact from 3 to 4 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
 


### PR DESCRIPTION
The ‘potential breaking changes’ mentioned in their change log were indeed breaking for us, probably because the `.env` file no longer gets considered.

Other people have the same problem, see comments on the PR: https://github.com/actions/upload-pages-artifact/pull/102 and a new issue: https://github.com/actions/upload-pages-artifact/issues/129

Reverting for now. Let’s wait and see if an upcoming version of this action adds an option to specify which dotfiles to deploy.