### PR TITLE
chore: Group patch and minor GitHub Actions updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 1 # Wait for one day after release before updating a dependency
+    groups:
+      patch-and-minor-actions:
+        applies-to: "version-updates"
+        update-types:
+          - "patch"
+          - "minor"
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
Mirrors the existing grouping for the npm ecosystem so patch and minor GitHub Actions bumps land in a single weekly PR instead of one per action.