### PR TITLE
fix(eslint): Unbreak lint by removing redundant tseslint spread

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,6 @@ import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
 import nextTypescript from 'eslint-config-next/typescript'
 import perfectionist from 'eslint-plugin-perfectionist'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
-import tseslint from 'typescript-eslint'
 
 const perfectionistCustomSizesGroups = {
   customGroups: [
@@ -70,7 +69,6 @@ export default [
       '**/out',
     ],
   },
-  ...tseslint.configs.recommended,
   {
     languageOptions: {
       parser: tsParser,

--- a/src/app/amopis/_components/AmopisMenu/AmopisMenu.tsx
+++ b/src/app/amopis/_components/AmopisMenu/AmopisMenu.tsx
@@ -3,8 +3,8 @@
 import type { MenuProps } from '@amsterdam/design-system-react'
 
 import { Menu } from '@amsterdam/design-system-react'
-import { HTMLAttributes } from 'react'
 import { usePathname } from 'next/navigation'
+import { HTMLAttributes } from 'react'
 
 import { menuItems } from './menuItems'
 

--- a/src/app/amopis/page.tsx
+++ b/src/app/amopis/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 
 export default function AmopisIndex() {
   const router = useRouter()

--- a/src/app/amopis/projecten/page.tsx
+++ b/src/app/amopis/projecten/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 
 export default function Projecten() {
   const router = useRouter()


### PR DESCRIPTION
eslint-config-next/typescript already registers the @typescript-eslint plugin, so the explicit `...tseslint.configs.recommended` spread caused "Cannot redefine plugin @typescript-eslint", failing `eslint .` entirely.

Removing it lets lint run again, which surfaced 3 pre-existing perfectionist/sort-imports violations in the amopis pages (masked while the config errored). Auto-fixed those so lint passes.