### PR TITLE
feat(img): Add loading="eager" to above-the-fold images

### DIFF
--- a/src/app/amsterdam/bestuur-en-organisatie/college-van-burgemeester-en-wethouders/page.tsx
+++ b/src/app/amsterdam/bestuur-en-organisatie/college-van-burgemeester-en-wethouders/page.tsx
@@ -119,7 +119,7 @@ export default function CollegeVanBurgemeesterEnWethouders() {
           <Paragraph size="large">Het dagelijks bestuur van onze gemeente uitgebreid in beeld.</Paragraph>
         </Grid.Cell>
       </Grid>
-      <NextImage alt="" className="ams-image ams-aspect-ratio-16-5" src={municipalExecutive} />
+      <NextImage alt="" className="ams-image ams-aspect-ratio-16-5" loading="eager" src={municipalExecutive} />
       <Grid gapVertical="large" paddingVertical="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 12 }} start={{ narrow: 1, medium: 2, wide: 1 }}>
           <Heading className="ams-mb-s" level={2}>

--- a/src/app/amsterdam/bestuur-en-organisatie/gemeenteraad/page.tsx
+++ b/src/app/amsterdam/bestuur-en-organisatie/gemeenteraad/page.tsx
@@ -84,7 +84,7 @@ export default function Gemeenteraad() {
           </Paragraph>
         </Grid.Cell>
       </Grid>
-      <NextImage alt="" className="ams-image ams-aspect-ratio-16-5" src={cityCouncilImage} />
+      <NextImage alt="" className="ams-image ams-aspect-ratio-16-5" loading="eager" src={cityCouncilImage} />
       <Grid gapVertical="large" paddingVertical="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={1}>
           <Heading className="ams-mb-xs" level={2} size="level-3">

--- a/src/app/amsterdam/kunst-en-cultuur/page.tsx
+++ b/src/app/amsterdam/kunst-en-cultuur/page.tsx
@@ -30,7 +30,7 @@ function KunstEnCultuur() {
           </Paragraph>
         </Grid.Cell>
         <Grid.Cell span={{ narrow: 4, medium: 8, wide: 8 }}>
-          <NextImage alt="" className="ams-image" src={artAndCultureImage} />
+          <NextImage alt="" className="ams-image" loading="eager" src={artAndCultureImage} />
         </Grid.Cell>
       </Grid>
       <Grid paddingBottom="x-large">

--- a/src/app/amsterdam/nieuws/page.tsx
+++ b/src/app/amsterdam/nieuws/page.tsx
@@ -37,7 +37,7 @@ function Nieuws() {
             </Paragraph>
           </Grid.Cell>
           <Grid.Cell span={6}>
-            <NextImage alt="" className="ams-image" src={fatbikesImage} />
+            <NextImage alt="" className="ams-image" loading="eager" src={fatbikesImage} />
           </Grid.Cell>
         </Grid>
         <Grid paddingBottom="x-large">

--- a/src/app/amsterdam/page.tsx
+++ b/src/app/amsterdam/page.tsx
@@ -104,7 +104,7 @@ function HomePage() {
         </Grid>
       )}
       <Overlap>
-        <NextImage alt="" className="ams-image ams-aspect-ratio-16-5" src={vindenImage} />
+        <NextImage alt="" className="ams-image ams-aspect-ratio-16-5" loading="eager" src={vindenImage} />
         <Grid style={{ alignSelf: 'center' }}>
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
             <SearchField onSubmit={() => {}}>


### PR DESCRIPTION
Hero/intro images that are likely above the fold are fetched eagerly instead of lazily, so the browser does not defer them.

Pages: /amsterdam, /amsterdam/nieuws, /amsterdam/kunst-en-cultuur, /amsterdam/bestuur-en-organisatie/college-van-burgemeester-en-wethouders, /amsterdam/bestuur-en-organisatie/gemeenteraad.