### PR TITLE
fix(basePath): Route internal links missed by the ADS 4.2.0 migration through NextLink

### DIFF
--- a/src/app/afspraak-maken/bedankt/page.tsx
+++ b/src/app/afspraak-maken/bedankt/page.tsx
@@ -2,6 +2,7 @@
 
 import { Grid, Heading, Link, Paragraph, StandaloneLink, UnorderedList } from '@amsterdam/design-system-react'
 import { DownloadIcon } from '@amsterdam/design-system-react-icons'
+import NextLink from 'next/link'
 
 export default function Bedankt() {
   return (
@@ -25,7 +26,9 @@ export default function Bedankt() {
             Download overzicht afspraak PDF, 1MB
           </StandaloneLink>
         </div>
-        <StandaloneLink href="/afspraak-maken">Sluit het formulier</StandaloneLink>
+        <StandaloneLink href="/afspraak-maken" linkComponent={NextLink}>
+          Sluit het formulier
+        </StandaloneLink>
       </Grid.Cell>
     </Grid>
   )

--- a/src/app/amopis/_components/AmopisMenu/AmopisMenu.tsx
+++ b/src/app/amopis/_components/AmopisMenu/AmopisMenu.tsx
@@ -3,6 +3,7 @@
 import type { MenuProps } from '@amsterdam/design-system-react'
 
 import { Menu } from '@amsterdam/design-system-react'
+import NextLink from 'next/link'
 import { usePathname } from 'next/navigation'
 import { HTMLAttributes } from 'react'
 
@@ -23,6 +24,7 @@ export function AmopisMenu(props: AmopisMenuProps) {
           href={href}
           icon={icon}
           key={text}
+          linkComponent={NextLink}
         >
           {text}
         </Menu.Link>

--- a/src/app/amopis/projecten/projectdetails/kerngegevens/page.tsx
+++ b/src/app/amopis/projecten/projectdetails/kerngegevens/page.tsx
@@ -13,6 +13,7 @@ import {
   Row,
 } from '@amsterdam/design-system-react'
 import { DocumentWithPencilIcon, MailIcon } from '@amsterdam/design-system-react-icons'
+import NextLink from 'next/link'
 
 import { ProjectNavigation } from '../../_components/ProjectNavigation/ProjectNavigation'
 
@@ -22,7 +23,9 @@ function Kerngegevens() {
       <Grid.Cell appearance="transparent" span="all">
         <Breadcrumb>
           <Breadcrumb.Link href="#">Dashboard</Breadcrumb.Link>
-          <Breadcrumb.Link href="/amopis/projecten">Projecten</Breadcrumb.Link>
+          <Breadcrumb.Link href="/amopis/projecten" linkComponent={NextLink}>
+            Projecten
+          </Breadcrumb.Link>
         </Breadcrumb>
       </Grid.Cell>
     </Grid>,


### PR DESCRIPTION
Three ADS link components rendered plain anchors with raw internal hrefs and no linkComponent, so Next.js never injected basePath — they 404'd in production under /design-system-prototypes:
- AmopisMenu Menu.Link -> /amopis/projecten
- afspraak-maken/bedankt StandaloneLink -> /afspraak-maken
- amopis kerngegevens Breadcrumb.Link -> /amopis/projecten

Pass linkComponent={NextLink} so they route through Next.js and pick up basePath, matching the rest of the app. #711 migrated the files it touched; these were the residual that #707 had aimed to fix.